### PR TITLE
move constructor to abstract class

### DIFF
--- a/refactoring/dry-dont-repeat-yourself.md
+++ b/refactoring/dry-dont-repeat-yourself.md
@@ -68,6 +68,10 @@ Example which respects the DRY rule "Do not repeat yourself".
      abstract class AbstractConnection {
          protected $settings;
 
+         public function __construct( $settings ) {
+             $this->set_settings( $settings );
+         }
+
          protected function set_settings( $settings ) {
              if ( ! is_array( $settings ) ) {
                  throw new \Exception( 'Invalid settings' );
@@ -79,20 +83,12 @@ Example which respects the DRY rule "Do not repeat yourself".
      }
      
      class PartnerOneConnection extends AbstractConnection {
-         public function __construct( $settings ) {
-             $this->set_settings( $settings );
-         }
-         
          protected function connect() {
              //...
          }
      }
      
      class PartnerTwoConnection extends AbstractConnection {
-         public function __construct( $settings ) {
-             $this->set_settings( $settings );
-         }
-         
          protected function connect() {
              //...
          }


### PR DESCRIPTION
```
$ psysh
Psy Shell v0.8.2 (PHP 7.0.15-0ubuntu0.16.04.4 — cli) by Justin Hileman
>>> abstract class foo { public function __construct() { echo 'hello'; } }
=> null
>>> class bar extends foo {}
=> null
>>> new bar;
hello⏎
=> bar {#175}
>>>
```